### PR TITLE
Miryoku: fix key overrides array build error

### DIFF
--- a/keyboards/zsa/voyager/keymaps/bugroger/config.h
+++ b/keyboards/zsa/voyager/keymaps/bugroger/config.h
@@ -7,7 +7,11 @@
 
 #define XXX KC_NO
 
-#if defined (MIRYOKU_MAPPING_SHIFTED_ROWS)
+// Custom keycodes for altgr-intl layout
+#define C_A RALT(KC_Q) // ä
+#define C_O RALT(KC_P) // ö
+
+#if defined (MIRYOKU_MAPPING_SHIFTED_ROWS_EXTENDED_THUMBS_PINKIE_STAGGER)
 #define LAYOUT_miryoku( \
      K00, K01, K02, K03, K04,      K05, K06, K07, K08, K09, \
      K10, K11, K12, K13, K14,      K15, K16, K17, K18, K19, \
@@ -15,24 +19,10 @@
      N30, N31, K32, K33, K34,      K35, K36, K37, N38, N39 \
 ) \
 LAYOUT_voyager( \
-XXX, K00, K01, K02, K03, K04,      K05, K06, K07, K08, K09, XXX, \
-XXX, K10, K11, K12, K13, K14,      K15, K16, K17, K18, K19, XXX, \
-XXX, K20, K21, K22, K23, K24,      K25, K26, K27, K28, K29, XXX, \
-XXX, XXX, XXX, XXX, K32, XXX,      XXX, K37, XXX, XXX, XXX, XXX, \
-                    K33, K34,      K35, K36 \
-)
-#else
-#define LAYOUT_miryoku( \
-     K00, K01, K02, K03, K04,      K05, K06, K07, K08, K09, \
-     K10, K11, K12, K13, K14,      K15, K16, K17, K18, K19, \
-     K20, K21, K22, K23, K24,      K25, K26, K27, K28, K29, \
-     N30, N31, K32, K33, K34,      K35, K36, K37, N38, N39 \
-) \
-LAYOUT_voyager( \
-XXX, XXX, XXX, XXX, XXX, XXX,      XXX, XXX, XXX, XXX, XXX, XXX, \
-XXX, K00, K01, K02, K03, K04,      K05, K06, K07, K08, K09, XXX, \
-XXX, K10, K11, K12, K13, K14,      K15, K16, K17, K18, K19, XXX, \
-XXX, K20, K21, K22, K23, K24,      K25, K26, K27, K28, K29, XXX, \
+XXX, XXX, K01, K02, K03, K04,      K05, K06, K07, K08, XXX, XXX, \
+XXX, K00, K11, K12, K13, K14,      K15, K16, K17, K18, K09, XXX, \
+C_A, K10, K21, K22, K23, K24,      K25, K26, K27, K28, K19, C_O, \
+XXX, K20, XXX, XXX, K32, XXX,      XXX, K37, XXX, XXX, K29, XXX, \
                     K33, K34,      K35, K36 \
 )
 #endif

--- a/keyboards/zsa/voyager/keymaps/bugroger/rules.mk
+++ b/keyboards/zsa/voyager/keymaps/bugroger/rules.mk
@@ -1,9 +1,8 @@
 # Copyright 2023 Manna Harbour
 # https://github.com/manna-harbour/miryoku
 
-MIRYOKU_KLUDGE_THUMBCOMBOS=yes
-MIRYOKU_MAPPING_SHIFTED_ROWS=yes
-MIRYOKU_CLIPBOARD=MAC
+MIRYOKU_KLUDGE_THUMBCOMBOS = no
+MIRYOKU_MAPPING_SHIFTED_ROWS_EXTENDED_THUMBS_PINKIE_STAGGER = yes
 
 USER_NAME := miryoku
 SRC += features/achordion.c

--- a/users/miryoku/manna-harbour_miryoku.c
+++ b/users/miryoku/manna-harbour_miryoku.c
@@ -53,9 +53,8 @@ MIRYOKU_LAYER_LIST
 
 const key_override_t capsword_key_override = ko_make_basic(MOD_MASK_SHIFT, CW_TOGG, KC_CAPS);
 
-const key_override_t **key_overrides = (const key_override_t *[]){
+const key_override_t *key_overrides[] = {
     &capsword_key_override,
-    NULL
 };
 
 


### PR DESCRIPTION
ARRAY_SIZE macro an only be used for statically allocated arrays that have not been decayed into a pointer. See also
https://docs.qmk.fm/features/key_overrides#simple-example

I get the following build error on Arch Linux and the QMK docker container:
```
quantum/keymap_introspection.c: In function 'key_override_count_raw':
quantum/util.h:47:89: error: division 'sizeof (const key_override_t ** {aka const struct key_override_t **}) / sizeof (const key_override_t * {aka const struct key_override_t *})' does not compute the number of array elements [-Werror=sizeof-pointer-div]
   47 | #    define ARRAY_SIZE(array) (__builtin_choose_expr(IS_ARRAY((array)), sizeof((array)) / sizeof((array)[0]), (void)0))
```
